### PR TITLE
Fix Vote update method

### DIFF
--- a/src/main/java/com/axiomq/starwars/services/impl/VoteServiceImpl.java
+++ b/src/main/java/com/axiomq/starwars/services/impl/VoteServiceImpl.java
@@ -22,6 +22,7 @@ import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.security.Principal;
 import java.util.List;
+import java.util.Objects;
 import java.util.UUID;
 
 @RequiredArgsConstructor
@@ -78,12 +79,17 @@ public class VoteServiceImpl implements VoteService {
         if(!existing.getUser().getEmail().equals(principal.getName()))
             throw new ObjectNotFoundException("You are not authorized for this action.");
 
-        existing.setComment(vote.getComment());
-        existing.setValue(vote.getValue());
+        if(vote.getComment() != null)
+            existing.setComment(vote.getComment());
 
-        Path path = saveFile(vote, icon);
-        existing.setIcon(path.getFileName().toString());
-        existing.setUrl(path.toString());
+        if(vote.getValue() != null)
+            existing.setValue(vote.getValue());
+
+        if(!Objects.equals(icon.getOriginalFilename(), "")) {
+            Path path = saveFile(vote, icon);
+            existing.setIcon(path.getFileName().toString());
+            existing.setUrl(path.toString());
+        }
 
         return voteRepository.save(existing);
     }

--- a/src/main/java/com/axiomq/starwars/web/controllers/VoteController.java
+++ b/src/main/java/com/axiomq/starwars/web/controllers/VoteController.java
@@ -5,6 +5,7 @@ import com.axiomq.starwars.services.VoteService;
 import com.axiomq.starwars.web.dtos.vote.VoteMapper;
 import com.axiomq.starwars.web.dtos.vote.VoteRequest;
 import com.axiomq.starwars.web.dtos.vote.VoteResponse;
+import com.axiomq.starwars.web.dtos.vote.VoteUpdateDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -13,6 +14,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
+import javax.annotation.Nullable;
 import javax.validation.Valid;
 import java.io.IOException;
 import java.security.Principal;
@@ -75,9 +77,9 @@ public class VoteController {
     @PutMapping("/{id}")
     public VoteResponse updateVote(@PathVariable("id") Long id,
                                    @RequestPart("icon") MultipartFile icon,
-                                   @Valid @RequestPart("request") VoteRequest voteRequest,
+                                   @Valid @RequestPart("request") VoteUpdateDto voteUpdateDto,
                                    Principal principal) {
-        Vote vote = voteService.updateVote(VoteMapper.INSTANCE.fromReqDto(voteRequest), icon, id, principal);
+        Vote vote = voteService.updateVote(VoteMapper.INSTANCE.fromUpdDto(voteUpdateDto), icon, id, principal);
         return VoteMapper.INSTANCE.toResDto(vote);
     }
 

--- a/src/main/java/com/axiomq/starwars/web/dtos/vote/VoteMapper.java
+++ b/src/main/java/com/axiomq/starwars/web/dtos/vote/VoteMapper.java
@@ -2,6 +2,7 @@ package com.axiomq.starwars.web.dtos.vote;
 
 import com.axiomq.starwars.entities.Vote;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 import org.mapstruct.ReportingPolicy;
 import org.mapstruct.factory.Mappers;
 
@@ -9,9 +10,10 @@ import org.mapstruct.factory.Mappers;
 public interface VoteMapper {
     VoteMapper INSTANCE = Mappers.getMapper(VoteMapper.class);
 
-    VoteRequest toReqDto(Vote vote);
     Vote fromReqDto(VoteRequest voteRequest);
 
+    Vote fromUpdDto(VoteUpdateDto voteUpdateDto);
+
+    @Mapping(source = "character.id", target = "characterId")
     VoteResponse toResDto(Vote vote);
-    Vote fromResDto(VoteResponse voteResponse);
 }

--- a/src/main/java/com/axiomq/starwars/web/dtos/vote/VoteResponse.java
+++ b/src/main/java/com/axiomq/starwars/web/dtos/vote/VoteResponse.java
@@ -27,4 +27,7 @@ public class VoteResponse {
 
     @Schema(description = "Icon's full path")
     private String url;
+
+    @Schema(description = "Id of character")
+    private Long characterId;
 }

--- a/src/main/java/com/axiomq/starwars/web/dtos/vote/VoteUpdateDto.java
+++ b/src/main/java/com/axiomq/starwars/web/dtos/vote/VoteUpdateDto.java
@@ -1,0 +1,27 @@
+package com.axiomq.starwars.web.dtos.vote;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.validator.constraints.Range;
+
+import javax.validation.constraints.Size;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Schema(description = "Vote update object")
+public class VoteUpdateDto {
+
+    @Schema(description = "User's rate of Character")
+    @Range(min = 1, max = 10, message = "Value must be between 1 and 10.")
+    private Integer value;
+
+    @Schema(description = "Comment about character")
+    @Size(max = 120, message = "Comment can hold only 120 characters.")
+    private String comment;
+
+}


### PR DESCRIPTION
Now fields that are null are not overwriting fields in database. Able to update only a part of a Vote object.